### PR TITLE
Fix critical sign_up error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,8 +23,8 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up){|u| u.permit(:first_name, :last_name, :phone, :email, :password, :remember_me)}
+    devise_parameter_sanitizer.permit(:sign_up){|u| u.permit(:first_name, :last_name, :phone, :email, :password, :password_confirmation, :remember_me)}
     devise_parameter_sanitizer.permit(:sign_in){|u| u.permit(:email, :password, :remember_me)}
-    devise_parameter_sanitizer.permit(:account_update){|u| u.permit(:first_name, :last_name, :phone, :email, :password, :remember_me)}
+    devise_parameter_sanitizer.permit(:account_update){|u| u.permit(:first_name, :last_name, :phone, :email, :password, :password_confirmation, :remember_me)}
   end
 end


### PR DESCRIPTION
The password_confirmation field was not being passed through, so the user was stuck with whatever password was put in the password field. 

NOTE: Devise doesn't complain if you sanitize the parameters even if you have the configuration set to confirm the password. 