### PR TITLE
Oil meter now displays correct value based on max_value

### DIFF
--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -53,7 +53,8 @@ class CarsController < ApplicationController
 	end
 
 	def find_car
+		max_value = 5000
 		@car = Car.find(params[:id])
-		@car.oil_change? ? @oil_change = @car.oil_change? : @oil_change = @car.mileage
+		@car.oil_change? ? @oil_change = @car.oil_change? : ( (@car.mileage > max_value) ? max_value : @car.mileage )
 	end
 end

--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -55,6 +55,6 @@ class CarsController < ApplicationController
 	def find_car
 		max_value = 5000
 		@car = Car.find(params[:id])
-		@car.oil_change? ? @oil_change = @car.oil_change? : ( (@car.mileage > max_value) ? max_value : @car.mileage )
+		@car.oil_change? ? @oil_change = @car.oil_change? : @oil_change = ( (@car.mileage > max_value) ? max_value : @car.mileage)
 	end
 end

--- a/app/views/cars/show.html.erb
+++ b/app/views/cars/show.html.erb
@@ -117,7 +117,7 @@
                         .call(gauge);
 
                 segDisplay.value((<%= @car.mileage %>/1000));
-                gauge.value(10);
+                gauge.value(<%= @car.mileage %>/1000);
 
                     console.log(gauge.value);
             </script>

--- a/app/views/cars/show.html.erb
+++ b/app/views/cars/show.html.erb
@@ -98,7 +98,7 @@
                         .tickSize(10, 8, 10)
                         .tickPadding(5)
                         .scale(d3.scale.linear()
-                                .domain([0, 160])
+                                .domain([0, 100])
                                 .range([-3*Math.PI/4, 3*Math.PI/4]));
 
                 var segDisplay = iopctrl.segdisplay()
@@ -116,8 +116,8 @@
                         .attr("class", "gauge")
                         .call(gauge);
 
-                segDisplay.value(<%= @car.mileage %>);
-                gauge.value((<%= @car.mileage %>/60000)*60);
+                segDisplay.value((<%= @car.mileage %>/1000));
+                gauge.value(10);
 
                     console.log(gauge.value);
             </script>


### PR DESCRIPTION
NOTE: Still need to refactor our calculation in the back-end

NOTE: The speedometer now displays the current mileage of the /1000 and I added some ticks to it as well. However, we have no way to add like a "/miles" text value so that the user can readily now what they are looking at. 

TODO: Front end needs to have a way to retrieve the gauge value to test whether that value is over the threshold, in which we need to add a flashing JS object that notifies the user of a tire change.